### PR TITLE
Feature: Logplex token from URL.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,10 +12,19 @@ Lpxc is a fast & efficient client for sending log messages to Heroku's logplex. 
 $ gem install lpxc
 ```
 
+Specifying a logplex token.
 ```ruby
+ENV['LOGPLEX_URL'] = 'https://east.logplex.io/logs'
 require 'lpxc'
 lpxc = Lpxc.new
 lpxc.puts("hello world", 't.123')
+```
+Relying on the token set in the `$LOGPLEX_URL`.
+```ruby
+ENV['LOGPLEX_URL'] = 'https://t.123@east.logplex.io/logs'
+require 'lpxc'
+lpxc = Lpxc.new
+lpxc.puts("hello world")
 ```
 
 ## Runing Tests


### PR DESCRIPTION
Related: #5

A logplex token can be placed in the user portion
of the URL. E.g. https://user@host/path. If no token
is passed to #puts, and there wasn't a token passed into
the initializer, we will rely on whatever is in the logplex url.
