### PR TITLE
Expose Flush API

### DIFF
--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -13,19 +13,15 @@ class LockableSizedQueue < SizedQueue
   def synchronize
     @locker.synchronize {yield}
   end
-
-  def full?
-    @locker.synchronize do
-      return size == max
-    end
-  end
 end
 
 class FlushableLockableSizedQueue < LockableSizedQueue
   def flush
-    synchronize do
-      return self.size.times.map {self.deq}
-    end
+    synchronize {self.size.times.map {self.deq}}
+  end
+
+  def full?
+    synchronize {size == max}
   end
 end
 

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -89,6 +89,7 @@ class Lpxc
     #However this should never happen since the next command will flush
     #the queue if we add the last item.
     q.enq({:t => Time.now.utc, :token => tok, :msg => msg})
+    # Consequently we flush the entire client if any queue is full.
     flush if q.full?
   end
 

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -16,7 +16,11 @@ class LogMsgQueue
   end
 
   def flush
-    @locker.synchronize {@array.size.times.map {@array.pop}}
+    @locker.synchronize do
+      old = @array
+      @array = []
+      return old
+    end
   end
 
   def full?

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -84,11 +84,8 @@ class Lpxc
       #to logplex must only contain log messages belonging to a single token.
       q = @hash[tok] ||= LogMsgQueue.new(@batch_size)
     end
-    #This call will block if the queue is full.
-    #However this should never happen since the next command will flush
-    #the queue if we add the last item.
     q.enqueue({:t => Time.now.utc, :token => tok, :msg => msg})
-    # Consequently we flush the entire client if any queue is full.
+    # Flush all of the queues if any queue is full.
     flush if q.full?
   end
 

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -20,7 +20,7 @@ class LogMsgQueue
   end
 
   def full?
-    @locker.synchronize {@array.size == @max}
+    @locker.synchronize {@array.size >= @max}
   end
 end
 

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -107,7 +107,7 @@ class Lpxc
       @hash.each do |tok, queue|
         #Copy the messages from the queue into the payload array.
         payloads = queue.flush
-        return if payloads.nil? || payloads.empty?
+        next if payloads.nil? || payloads.empty?
 
         #Use the payloads array to build a string that will be
         #used as the http body for the logplex request.

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -107,7 +107,13 @@ class Lpxc
       to_be_processed = @hash
       @hash = {}
     end
-    to_be_processed.each do |tok, queue|
+    process_hash(to_be_processed)
+  end
+
+  private
+
+  def process_hash(h)
+    h.each do |tok, queue|
       #Copy the messages from the queue into the payload array.
       payloads = queue.flush
       next if payloads.nil? || payloads.empty?
@@ -130,8 +136,6 @@ class Lpxc
       @last_flush = Time.now
     end
   end
-
-  private
 
   #This method must be called in order for the messages to be sent to Logplex.
   #This method also spawns a thread that allows the messages to be batched.

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -83,10 +83,10 @@ class Lpxc
   #We pass the request off into the request queue so that the request
   #can be sent to LOGPLEX_URL.
   def flush
-    @hash.each do |tok, msgs|
+    @hash.each do |tok, queue|
       #Copy the messages from the queue into the payload array.
       payloads = []
-      msgs.size.times {payloads << msgs.deq}
+      queue.size.times {payloads << queue.deq}
       return if payloads.nil? || payloads.empty?
 
       #Use the payloads array to build a string that will be

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -17,7 +17,7 @@ end
 
 class FlushableLockableSizedQueue < LockableSizedQueue
   def flush
-    synchronize {self.size.times.map {self.deq}}
+    synchronize {size.times.map {deq}}
   end
 
   def full?

--- a/test.rb
+++ b/test.rb
@@ -95,4 +95,15 @@ class LpxcTest < LpxcTestBase #:nodoc:
     c.wait
     assert_equal(2, TestServer.results.length)
   end
+
+  def test_flushing_the_client
+    reqs = SizedQueue.new(1)
+    # Make the batch size much larger than the input.
+    c = Lpxc.new(:request_queue => reqs, :batch_size => 10)
+    c.puts('hello world', 't.123')
+    c.flush
+    c.wait
+    assert_equal(1, TestServer.results.length)
+  end
+
 end


### PR DESCRIPTION
This PR accomplishes two things:
1. Expose a flush API such that we have API similarity to Ruby's StringIO class.
2. Introduce fine grained locks which will make the system more reasonable.

These changes were primarily motivated by this issue: ryandotsmith/lpxc#7
