### PR TITLE
Multiconn

### DIFF
--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -60,8 +60,8 @@ class Lpxc
     @batch_size = opts[:batch_size] || 300
     @flush_interval = opts[:flush_interval] || 0.5
     @user_agent = opts[:user_agent] || ENV["LPXC_USER_AGENT"] || "Lpxc (Ruby #{RUBY_VERSION})"
-    @logplex_url = URI(opts[:logplex_url] || ENV["LOGPLEX_URL"] ||
-      raise("Must set logplex url."))
+    @logplex_url = URI((opts[:logplex_url] || ENV["LOGPLEX_URL"] ||
+      raise("Must set logplex url.")).to_s)
 
     #Keep track of the number of requests that the outlet
     #is processing. This value is used by the wait function.
@@ -79,7 +79,7 @@ class Lpxc
   #and use it to send msg using the token from the URL.
   def self.puts(msg, url, opts={})
     @lock = Mutex.new
-    url = url.is_a?(URI) ? url : URI.parse(url)
+    url = url.is_a?(URI) ? url : URI(url)
     server = [url.host, url.port, url.scheme]
     @clients ||= {}
     c = @lock.synchronize { @clients[server] ||= Lpxc.new(:logplex_url => url) }

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -92,7 +92,7 @@ class Lpxc
     #Start the processing threads.
     Thread.new {outlet}
     Thread.new {delay_flush} unless opts[:disable_delay_flush]
-    at_exit {flush} unless opts[:disable_at_exit_flush]
+    at_exit {wait} unless opts[:disable_at_exit_flush]
   end
 
   #Automatically create an Lpxc client object for a given URL if none exists,

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -59,6 +59,7 @@ class Lpxc
     @conn_timeout = opts[:conn_timeout] || 2
     @batch_size = opts[:batch_size] || 300
     @flush_interval = opts[:flush_interval] || 0.5
+    @user_agent = opts[:user_agent] || ENV["LPXC_USER_AGENT"] || "Lpxc (Ruby #{RUBY_VERSION})"
     @logplex_url = URI(opts[:logplex_url] || ENV["LOGPLEX_URL"] ||
       raise("Must set logplex url."))
 
@@ -131,6 +132,7 @@ class Lpxc
       req = Net::HTTP::Post.new(@logplex_url.path)
       req.basic_auth("token", tok)
       req.add_field('Content-Type', 'application/logplex-1')
+      req.add_field('User-Agent', @user_agent) if @user_agent
       req.body = body
       @request_queue.enq(req)
       @last_flush = Time.now

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -77,12 +77,13 @@ class Lpxc
 
   #Automatically create an Lpxc client object for a given URL if none exists,
   #and use it to send msg using the token from the URL.
-  def self.puts(msg, url)
+  def self.puts(msg, url, opts={})
+    @lock = Mutex.new
     url = url.is_a?(URI) ? url : URI.parse(url)
     server = [url.host, url.port, url.scheme]
     @clients ||= {}
-    client = @clients.synchronize { @clients[server] ||= Lpxc.new(opts) }
-    client.puts(msg, url.password)
+    c = @lock.synchronize { @clients[server] ||= Lpxc.new(:logplex_url => url) }
+    c.puts(msg, url.password)
   end
 
   #The interface to publish logs into the stream.

--- a/lib/lpxc.rb
+++ b/lib/lpxc.rb
@@ -75,6 +75,16 @@ class Lpxc
     Thread.new {delay_flush} if opts[:disable_delay_flush].nil?
   end
 
+  #Automatically create an Lpxc client object for a given URL if none exists,
+  #and use it to send msg using the token from the URL.
+  def self.puts(msg, url)
+    url = url.is_a?(URI) ? url : URI.parse(url)
+    server = [url.host, url.port, url.scheme]
+    @clients ||= {}
+    client = @clients.synchronize { @clients[server] ||= Lpxc.new(opts) }
+    client.puts(msg, url.password)
+  end
+
   #The interface to publish logs into the stream.
   #This function will set the log message to the current time in UTC.
   #If the buffer for this token's log messages is full, it will flush the buffer.

--- a/test.rb
+++ b/test.rb
@@ -121,9 +121,9 @@ class LpxcTest < LpxcTestBase #:nodoc:
     assert_equal(2, Lpxc.clients.length)
     assert_equal(1, @test_server.results.length)
     assert_equal(2, ts2.results.length)
-    assert_match(ts2.results.first, /hello second/)
-    assert_match(ts2.results.first, /second again/)
-    assert_match(ts2.results.last, /hello third/)
+    assert_match(/hello second/, ts2.results.first)
+    assert_match(/second again/, ts2.results.first)
+    assert_match(/hello third/, ts2.results.last)
   ensure
     ts2.stop
   end

--- a/test.rb
+++ b/test.rb
@@ -112,7 +112,7 @@ class LpxcTest < LpxcTestBase #:nodoc:
   def test_auto_multiplexing
     ts2 = TestServer.new.start(5001)
 
-    Lpxc.puts("hello first", LOGPLEX_URL)
+    Lpxc.puts("hello first", LOGPLEX_URL.to_s)
     Lpxc.puts("hello second", 'http://token:second@localhost:5001/logs')
     Lpxc.puts("second again", 'http://token:second@localhost:5001/logs')
     Lpxc.puts("hello third", 'http://token:third@localhost:5001/logs')


### PR DESCRIPTION
This adds an `Lpxc.puts` method which operates in terms of URLs; it re-uses `Lpxc` clients for each host/port pair it's called with and pulls the token out of the URL.

I also threw in a patch to set the user-agent.
